### PR TITLE
Conditionally render Spline based on GPU tier

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@splinetool/runtime": "^1.9.82",
         "@tailwindcss/vite": "^4.1.3",
         "@types/react-scroll": "^1.8.10",
+        "detect-gpu": "^5.0.70",
         "framer-motion": "^12.9.2",
         "motion": "^12.8.0",
         "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@types/react-scroll':
         specifier: ^1.8.10
         version: 1.8.10
+      detect-gpu:
+        specifier: ^5.0.70
+        version: 5.0.70
       framer-motion:
         specifier: ^12.9.2
         version: 12.9.2(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1004,6 +1007,9 @@ packages:
       supports-color:
         optional: true
 
+  detect-gpu@5.0.70:
+    resolution: {integrity: sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==}
+
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
     engines: {node: '>=8'}
@@ -1528,6 +1534,9 @@ packages:
         optional: true
       yaml:
         optional: true
+
+  webgl-constants@1.1.1:
+    resolution: {integrity: sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2701,6 +2710,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  detect-gpu@5.0.70:
+    dependencies:
+      webgl-constants: 1.1.1
+
   detect-libc@2.0.3: {}
 
   electron-to-chromium@1.5.134: {}
@@ -3129,6 +3142,8 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.29.2
+
+  webgl-constants@1.1.1: {}
 
   which@2.0.2:
     dependencies:

--- a/src/components/sections/spur.section.tsx
+++ b/src/components/sections/spur.section.tsx
@@ -1,5 +1,4 @@
 import type React from 'react';
-import { useState } from 'react';
 import {
     Box,
     Flex,
@@ -11,11 +10,11 @@ import {
     Container,
 } from '@chakra-ui/react';
 import { keyframes } from '@emotion/react';
-import Spline from '@splinetool/react-spline';
 import { useInView } from 'react-intersection-observer';
 import { about2Strings } from '@locales';
 import { links } from '@data';
 import type { NavbarMeta } from '@components';
+import { SplineTarget } from '@components';
 import { Knot1, Knot8 } from '@assets';
 
 export const NavbarInfo: NavbarMeta = {
@@ -31,20 +30,10 @@ const spin = keyframes`
 `;
 
 export const Spur: React.FC = () => {
-    const [isSplineLoaded, setIsSplineLoaded] = useState(false);
-    const [splineError, setSplineError] = useState(false);
     const { ref, inView } = useInView({
         threshold: 0.1,
         triggerOnce: true,
     });
-
-    function onSplineLoad() {
-        setIsSplineLoaded(true);
-    }
-    function onSplineError(error: unknown) {
-        console.error('spline loading error:', error);
-        setSplineError(true);
-    }
 
     return (
         <section
@@ -71,36 +60,16 @@ export const Spur: React.FC = () => {
                     md: 'linear-gradient(to left, black 60%, rgba(0,0,0,0.5) 85%, rgba(0,0,0,0.02) 100%)',
                 }}
             >
-                {!splineError && (
-                    <Box
-                        position="absolute"
-                        top="0"
-                        left="0"
-                        width="100%"
-                        height="100%"
-                        opacity={isSplineLoaded ? 1 : 0}
-                        transition="opacity 0.5s ease-in"
-                    >
-                        {inView && (
-                            <Spline
-                                scene={splineSceneUrl}
-                                onLoad={onSplineLoad}
-                                onError={onSplineError}
-                                style={{ width: '100%', height: '100%' }}
-                            />
-                        )}
-                    </Box>
-                )}
-                {(!inView || !isSplineLoaded || splineError) && (
-                    <Box
-                        position="absolute"
-                        top="0"
-                        left="0"
-                        width="100%"
-                        height="100%"
-                        bg="black"
-                    />
-                )}
+                <SplineTarget
+                    id="spur-spline"
+                    minHeight="100%"
+                    height="100%"
+                    width="100%"
+                    position="absolute"
+                    top={0}
+                    left={0}
+                    bg="black"
+                />
             </Box>
 
             <Container


### PR DESCRIPTION
## Description
This PR introduces GPU tier detection (using `detect-gpu`) to conditionally render the global Spline animation. This fixes performance issues on less gpu-capable devices or those with disabled hardware acceleration.

## Linked Issues
- Fixes #66 

## Testing
![](https://bufo.fun/smolBufos/bufo-salivating.png)

## Reviewer Checklist
When reviewing this PR, make sure to keep the following in mind:
- This PR should not span too many unrelated tickets or changes.
  - If it does, consider breaking it up into smaller PRs.
- Is the code coverage acceptable?
- Does the preview deployment work as expected?
- Does this PR pass all tests?
- Does this PR have a clear list of issues that it closes?
- Does the code follow the style guidelines of the project?

## Author Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has an **assigned milestone**.

Additionally, make sure that:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
